### PR TITLE
Feature: VGA Driver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,4 +11,11 @@ name = "fractal_os"
 version = "0.1.0"
 dependencies = [
  "bootloader",
+ "volatile",
 ]
+
+[[package]]
+name = "volatile"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e000a949a4c792c46417a637bdf18ed39cfc70184318f609979e0fa03ab334c8"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,8 +11,25 @@ name = "fractal_os"
 version = "0.1.0"
 dependencies = [
  "bootloader",
+ "lazy_static",
+ "spin",
  "volatile",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+dependencies = [
+ "spin",
+]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "volatile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2018"
 
 [dependencies]
 bootloader = "0.9.11"
+volatile = "0.4.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,8 @@ edition = "2018"
 [dependencies]
 bootloader = "0.9.11"
 volatile = "0.4.1"
+spin = "0.5.2"
+
+[dependencies.lazy_static]
+version = "1.4.0"
+features = ["spin_no_std"]

--- a/README.md
+++ b/README.md
@@ -56,6 +56,21 @@ After generating a bootable image file, you can run Fractal easily on an emulato
 qemu-system-x86_64 -drive format=raw,file=target/x86_64-fractal_os/debug/bootimage-fractal_os.bin
 ```
 
+You can also run it with a cargo runner with the help of bootimage runner.
+
+```shell script
+cargo run
+```
+
+The above will point to the last build of the bootable image and will start an instance of QEMU.
+You can also provide specific target and pass through QEMU options.
+
+```shell script
+cargo run --target <target> -- [QEMU options]
+```
+
+Everything after the `--` will be passed to QEMU.
+
 ## Implementation Details
 
 The kernel is using the `compiler_builtins` crate along with its `mem` implementation.

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,8 @@ mod vga_buffer;
 
 // Calls on panic
 #[panic_handler]
-fn panic(_info: &PanicInfo) -> ! {
+fn panic(info: &PanicInfo) -> ! {
+    println!("[KERNEL_PANIC]: {}", info);
     loop {}
 }
 
@@ -23,7 +24,7 @@ fn panic(_info: &PanicInfo) -> ! {
 #[no_mangle]
 pub extern "C" fn _start() -> ! {
 
-    vga_buffer::print_test();
+    println!("Hello, world!");
 
     loop {}
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,5 @@
-/*
-    main.rs
-
-    Entry point of the kernel.
- */
-
-// Disable stdlib linking
-#![no_std]
-// Disable all rust-level entry points
-#![no_main]
+#![no_std] // Disable stdlib linking
+#![no_main] // Disable all rust-level entry points
 
 use core::panic::PanicInfo;
 
@@ -25,6 +17,8 @@ fn panic(info: &PanicInfo) -> ! {
 pub extern "C" fn _start() -> ! {
 
     println!("Hello, world!");
+    println!("My name is {}", "Martin");
+    print!("My favourite colour is {} and favourite word is {}", 42, 3.1417);
 
     loop {}
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@
 
 use core::panic::PanicInfo;
 
-static HELLO_WORLD: &[u8] = b"Hello, world!";
+mod vga_buffer;
 
 // Calls on panic
 #[panic_handler]
@@ -22,14 +22,8 @@ fn panic(_info: &PanicInfo) -> ! {
 // Don't mangle the entry point function name
 #[no_mangle]
 pub extern "C" fn _start() -> ! {
-    let vga_buffer = 0xb8000 as *mut u8;
 
-    for (i, &byte) in HELLO_WORLD.iter().enumerate() {
-        unsafe {
-            *vga_buffer.offset(i as isize * 2) = byte;
-            *vga_buffer.offset(i as isize * 2 + 1) = 0xb;
-        }
-    }
+    vga_buffer::print_test();
 
     loop {}
 }

--- a/src/vga_buffer.rs
+++ b/src/vga_buffer.rs
@@ -1,0 +1,116 @@
+/*
+    vga_buffers.rs
+ */
+
+use volatile::Volatile;
+use core::fmt;
+
+#[allow(dead_code)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[repr(u8)]
+pub enum Color {
+    Black = 0,
+    Blue = 1,
+    Green = 2,
+    Cyan = 3,
+    Red = 4,
+    Magenta = 5,
+    Brown = 6,
+    LightGray = 7,
+    DarkGray = 8,
+    LightBlue = 9,
+    LightGreen = 10,
+    LightCyan = 11,
+    LightRed = 12,
+    Pink = 13,
+    Yellow = 14,
+    White = 15
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[repr(transparent)]
+struct ColorCode(u8);
+
+impl ColorCode {
+    fn new(foreground: Color, background: Color) -> ColorCode {
+        ColorCode((background as u8) << 4 | (foreground as u8))
+    }
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[repr(C)]
+struct ScreenChar {
+    ascii_character: u8,
+    color_code: ColorCode
+}
+
+const BUFFER_HEIGHT: usize = 25;
+const BUFFER_WIDTH: usize = 80;
+
+#[repr(transparent)]
+struct Buffer {
+    chars: [[Volatile<ScreenChar>; BUFFER_WIDTH]; BUFFER_HEIGHT]
+}
+
+pub struct Writer {
+    column_position: usize,
+    color_code: ColorCode,
+    buffer: &'static mut Buffer
+}
+
+impl Writer {
+    pub fn write_byte(&mut self, byte: u8) {
+        match byte {
+            b'\n' => self.new_line(),
+            byte => {
+                if self.column_position >= BUFFER_WIDTH {
+                    self.new_line();
+                }
+
+                let row = BUFFER_HEIGHT - 1;
+                let col = self.column_position;
+                let color_code = self.color_code;
+
+                self.buffer.chars[row][col].write(ScreenChar {
+                    ascii_character: byte,
+                    color_code
+                });
+
+                self.column_position += 1;
+            }
+        }
+    }
+
+    pub fn write_string(&mut self, string: &str) {
+        for byte in string.bytes() {
+            match byte {
+                0x20..=0x7e | b'\n' => self.write_byte(byte), // printable ASCII characters.
+                _ => self.write_byte(0xfe) // not in the range of printable characters.
+            }
+        }
+    }
+
+    fn new_line(&mut self) {
+
+    }
+}
+
+impl fmt::Write for Writer {
+    fn write_str(&mut self, string: &str) -> fmt::Result {
+        self.write_string(string);
+        Ok(())
+    }
+}
+
+pub fn print_test() {
+    use core::fmt::Write;
+
+    let mut writer = Writer {
+        column_position: 0,
+        color_code: ColorCode::new(Color::Yellow, Color::Black),
+        buffer: unsafe { &mut *(0xb8000 as *mut Buffer) }
+    };
+
+    writer.write_string("Hello, world!");
+    write!(writer, "My name is {}", "Martin").unwrap();
+}

--- a/src/vga_buffer.rs
+++ b/src/vga_buffer.rs
@@ -2,6 +2,7 @@ use core::fmt;
 use spin::Mutex;
 use volatile::Volatile;
 use lazy_static::lazy_static;
+use core::ops::{Deref, DerefMut};
 
 lazy_static! {
     pub static ref WRITER: Mutex<Writer> = Mutex::new(Writer {
@@ -65,6 +66,20 @@ impl ColorCode {
 struct ScreenChar {
     ascii_character: u8,
     color_code: ColorCode
+}
+
+impl Deref for ScreenChar {
+    type Target = ScreenChar;
+
+    fn deref(&self) -> &Self::Target {
+        self
+    }
+}
+
+impl DerefMut for ScreenChar {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self
+    }
 }
 
 const BUFFER_HEIGHT: usize = 25;

--- a/src/vga_buffer.rs
+++ b/src/vga_buffer.rs
@@ -1,9 +1,32 @@
-/*
-    vga_buffers.rs
- */
-
-use volatile::Volatile;
 use core::fmt;
+use spin::Mutex;
+use volatile::Volatile;
+use lazy_static::lazy_static;
+
+lazy_static! {
+    pub static ref WRITER: Mutex<Writer> = Mutex::new(Writer {
+        column_position: 0,
+        color_code: ColorCode::new(Color::Yellow, Color::Black),
+        buffer: unsafe { &mut *(0xb8000 as *mut Buffer) }
+    });
+}
+
+#[macro_export]
+macro_rules! print {
+    ($($arg:tt)*) => ($crate::vga_buffer::_print(format_args!($($arg)*)));
+}
+
+#[macro_export]
+macro_rules! println {
+    () => ($crate::print!("\n"));
+    ($($arg:tt)*) => ($crate::print!("{}\n", format_args!($($arg)*)));
+}
+
+#[doc(hidden)]
+pub fn _print(args: fmt::Arguments) {
+    use core::fmt::Write;
+    WRITER.lock().write_fmt(args).unwrap();
+}
 
 #[allow(dead_code)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
@@ -91,7 +114,25 @@ impl Writer {
     }
 
     fn new_line(&mut self) {
+        for row in 1..BUFFER_HEIGHT {
+            for col in 0..BUFFER_WIDTH {
+                let character = self.buffer.chars[row][col].read();
+                self.buffer.chars[row - 1][col].write(character);
+            }
+        }
+        self.clear_row(BUFFER_HEIGHT - 1);
+        self.column_position = 0;
+    }
 
+    fn clear_row(&mut self, row: usize) {
+        let blank = ScreenChar {
+            ascii_character: b' ',
+            color_code: self.color_code
+        };
+
+        for col in 0..BUFFER_WIDTH {
+            self.buffer.chars[row][col].write(blank);
+        }
     }
 }
 
@@ -100,17 +141,4 @@ impl fmt::Write for Writer {
         self.write_string(string);
         Ok(())
     }
-}
-
-pub fn print_test() {
-    use core::fmt::Write;
-
-    let mut writer = Writer {
-        column_position: 0,
-        color_code: ColorCode::new(Color::Yellow, Color::Black),
-        buffer: unsafe { &mut *(0xb8000 as *mut Buffer) }
-    };
-
-    writer.write_string("Hello, world!");
-    write!(writer, "My name is {}", "Martin").unwrap();
 }


### PR DESCRIPTION
Creating a basic VGA driver to print text to the VGA buffer / screen.

- Keeping everything self contained with the help of `cargo run` and bootimage runners.
- Created a simple wrapper around writing directly to a VGA buffer.
- Contains only 1 unsafe operation which is retrieving the VGA buffer pointer.
- Exports println and print macros as core, so no need to import them.
- Previous volatile versions did not require to define Deref and DerefMut implementations, so added basic implementations.