### PR TITLE
feature/vga-driver: Adding the changes for .cargo/config.toml

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,3 +4,6 @@ build-std-features = ["compiler-builtins-mem"]
 
 [build]
 target = "x86_64-fractal_os.json"
+
+[target.'cfg(target_os = "none")']
+runner = "bootimage runner"


### PR DESCRIPTION
Previous commit missed off adding this directory and the changes for some reason, adding them now.

Adds the self contained-ness of cargo.