### PR TITLE
feature/cpu-exceptions: Added support for debug CPU exceptions.

### DIFF
--- a/src/interrupts.rs
+++ b/src/interrupts.rs
@@ -1,0 +1,24 @@
+use lazy_static::lazy_static;
+use x86_64::structures::idt::{InterruptDescriptorTable, InterruptStackFrame};
+use crate::println;
+
+lazy_static! {
+    static ref IDT: InterruptDescriptorTable = {
+        let mut idt = InterruptDescriptorTable::new();
+        idt.breakpoint.set_handler_fn(breakpoint_handler);
+        idt
+    };
+}
+
+pub fn init_idt() {
+    IDT.load();
+}
+
+extern "x86-interrupt" fn breakpoint_handler(stack_frame: &mut InterruptStackFrame) {
+    println!("[EXCEPTION]: BREAKPOINT\n{:#?}", stack_frame);
+}
+
+#[test_case]
+fn test_breakpoint_exception_handler() {
+    x86_64::instructions::interrupts::int3();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![no_std]
 #![cfg_attr(test, no_main)]
+#![feature(abi_x86_interrupt)]
 #![feature(custom_test_frameworks)]
 #![test_runner(crate::test_runner)]
 #![reexport_test_harness_main = "test_main"]
@@ -8,6 +9,11 @@ use core::panic::PanicInfo;
 
 pub mod serial;
 pub mod vga_buffer;
+pub mod interrupts;
+
+pub fn init() {
+    interrupts::init_idt();
+}
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 #[repr(u32)]
@@ -71,6 +77,7 @@ pub fn test_panic_handler(info: &PanicInfo) -> ! {
 #[cfg(test)]
 #[no_mangle]
 pub extern "C" fn _start() -> ! {
+    init();
     test_main();
 
     loop {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,10 @@ pub extern "C" fn _start() -> ! {
         42, 3.1417
     );
 
+    fractal_os::init();
+
+    x86_64::instructions::interrupts::int3();
+
     #[cfg(test)]
     test_main();
 


### PR DESCRIPTION
There are no ways of handling exceptions that may be thrown during runtime. Until now, that is.

- Kernel now contains a handler to handle int3 interrupt exceptions.

This will handle debug exceptions.