### PR TITLE
Feature: Handling double fault exceptions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -68,29 +68,29 @@ jobs:
       - name: Run Format
         run: xargo fmt --all -- --check
 
-#  clippy:
-#    name: Linting with Clippy
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Checkout Repository
-#        uses: actions/checkout@v2
-#
-#      - name: Install Rust Toolchain
-#        uses: actions-rs/toolchain@v1
-#        with:
-#          profile: minimal
-#          toolchain: nightly
-#          components: clippy, rust-src
-#          override: true
-#
-#      - name: Use Nightly Build
-#        run: rustup default nightly
-#
-#      - name: Run `cargo install xargo`
-#        run: cargo install xargo
-#
-#      - name: Run Linting Check
-#        run: xargo clippy
+  clippy:
+    name: Linting with Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Install Rust Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          components: clippy, rust-src
+          override: true
+
+      - name: Use Nightly Build
+        run: rustup default nightly
+
+      - name: Run `cargo install xargo`
+        run: cargo install xargo
+
+      - name: Run Linting Check
+        run: xargo clippy
 
 #  test:
 #    name: Test

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -68,29 +68,29 @@ jobs:
       - name: Run Format
         run: xargo fmt --all -- --check
 
-  clippy:
-    name: Linting with Clippy
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v2
-
-      - name: Install Rust Toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          components: clippy, rust-src
-          override: true
-
-      - name: Use Nightly Build
-        run: rustup default nightly
-
-      - name: Run `cargo install xargo`
-        run: cargo install xargo
-
-      - name: Run Linting Check
-        run: xargo clippy
+#  clippy:
+#    name: Linting with Clippy
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Checkout Repository
+#        uses: actions/checkout@v2
+#
+#      - name: Install Rust Toolchain
+#        uses: actions-rs/toolchain@v1
+#        with:
+#          profile: minimal
+#          toolchain: nightly
+#          components: clippy, rust-src
+#          override: true
+#
+#      - name: Use Nightly Build
+#        run: rustup default nightly
+#
+#      - name: Run `cargo install xargo`
+#        run: cargo install xargo
+#
+#      - name: Run Linting Check
+#        run: xargo clippy
 
 #  test:
 #    name: Test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,10 @@ test-timeout = 120
 name = "should_panic"
 harness = false
 
+[[test]]
+name = "stack_overflow"
+harness = false
+
 [dependencies]
 bootloader = "0.9.11"
 volatile = "0.4.1"

--- a/src/gdt.rs
+++ b/src/gdt.rs
@@ -37,7 +37,7 @@ lazy_static! {
             gdt,
             Selectors {
                 code_selector,
-                tss_selector
+                tss_selector,
             },
         )
     };

--- a/src/gdt.rs
+++ b/src/gdt.rs
@@ -1,7 +1,7 @@
-use x86_64::VirtAddr;
-use x86_64::structures::tss::TaskStateSegment;
-use x86_64::structures::gdt::{GlobalDescriptorTable, Descriptor, SegmentSelector};
 use lazy_static::lazy_static;
+use x86_64::structures::gdt::{GlobalDescriptorTable, Descriptor, SegmentSelector};
+use x86_64::structures::tss::TaskStateSegment;
+use x86_64::VirtAddr;
 
 pub const DOUBLE_FAULT_IST_INDEX: u16 = 0;
 
@@ -33,7 +33,13 @@ lazy_static! {
         let code_selector = gdt.add_entry(Descriptor::kernel_code_segment());
         let tss_selector = gdt.add_entry(Descriptor::tss_segment(&TSS));
 
-        (gdt, Selectors { code_selector, tss_selector })
+        (
+            gdt,
+            Selectors {
+                code_selector,
+                tss_selector
+            },
+        )
     };
 }
 

--- a/src/gdt.rs
+++ b/src/gdt.rs
@@ -1,0 +1,54 @@
+use x86_64::VirtAddr;
+use x86_64::structures::tss::TaskStateSegment;
+use x86_64::structures::gdt::{GlobalDescriptorTable, Descriptor, SegmentSelector};
+use lazy_static::lazy_static;
+
+pub const DOUBLE_FAULT_IST_INDEX: u16 = 0;
+
+struct Selectors {
+    code_selector: SegmentSelector,
+    tss_selector: SegmentSelector,
+}
+
+lazy_static! {
+    static ref TSS: TaskStateSegment = {
+        let mut tss = TaskStateSegment::new();
+        tss.interrupt_stack_table[DOUBLE_FAULT_IST_INDEX as usize] = {
+            const STACK_SIZE: usize = 4096 * 5;
+            static mut STACK: [u8; STACK_SIZE] = [0; STACK_SIZE];
+
+            let stack_start = VirtAddr::from_ptr(unsafe { &STACK });
+            let stack_end = stack_start + STACK_SIZE;
+
+            stack_end
+        };
+
+        tss
+    };
+}
+
+lazy_static! {
+    static ref GDT: (GlobalDescriptorTable, Selectors) = {
+        let mut gdt = GlobalDescriptorTable::new();
+        let code_selector = gdt.add_entry(Descriptor::kernel_code_segment());
+        let tss_selector = gdt.add_entry(Descriptor::tss_segment(&TSS));
+
+        (gdt, Selectors { code_selector, tss_selector })
+    };
+}
+
+pub fn init() {
+    use x86_64::instructions::segmentation::set_cs;
+    use x86_64::instructions::tables::load_tss;
+
+    GDT.0.load();
+
+    unsafe {
+        // Reloading the code segment register to make sure we
+        // are using the correct one with our GDT in it.
+        set_cs(GDT.1.code_selector);
+
+        // Load the TSS and tell the CPU to use it.
+        load_tss(GDT.1.tss_selector);
+    }
+}

--- a/src/gdt.rs
+++ b/src/gdt.rs
@@ -1,5 +1,5 @@
 use lazy_static::lazy_static;
-use x86_64::structures::gdt::{GlobalDescriptorTable, Descriptor, SegmentSelector};
+use x86_64::structures::gdt::{Descriptor, GlobalDescriptorTable, SegmentSelector};
 use x86_64::structures::tss::TaskStateSegment;
 use x86_64::VirtAddr;
 

--- a/src/interrupts.rs
+++ b/src/interrupts.rs
@@ -1,5 +1,5 @@
-use crate::println;
 use crate::gdt;
+use crate::println;
 use lazy_static::lazy_static;
 use x86_64::structures::idt::{InterruptDescriptorTable, InterruptStackFrame};
 
@@ -27,7 +27,8 @@ extern "x86-interrupt" fn breakpoint_handler(stack_frame: &mut InterruptStackFra
 }
 
 extern "x86-interrupt" fn double_fault_handler(
-    stack_frame: &mut InterruptStackFrame, _error_code: u64
+    stack_frame: &mut InterruptStackFrame,
+    _error_code: u64
 ) -> ! {
     panic!("[EXCEPTION]: DOUBLE FAULT\n{:#?}", stack_frame);
 }

--- a/src/interrupts.rs
+++ b/src/interrupts.rs
@@ -6,6 +6,7 @@ lazy_static! {
     static ref IDT: InterruptDescriptorTable = {
         let mut idt = InterruptDescriptorTable::new();
         idt.breakpoint.set_handler_fn(breakpoint_handler);
+        idt.double_fault.set_handler_fn(double_fault_handler);
         idt
     };
 }
@@ -16,6 +17,12 @@ pub fn init_idt() {
 
 extern "x86-interrupt" fn breakpoint_handler(stack_frame: &mut InterruptStackFrame) {
     println!("[EXCEPTION]: BREAKPOINT\n{:#?}", stack_frame);
+}
+
+extern "x86-interrupt" fn double_fault_handler(
+    stack_frame: &mut InterruptStackFrame, _error_code: u64
+) -> ! {
+    panic!("[EXCEPTION]: DOUBLE FAULT\n{:#?}", stack_frame);
 }
 
 #[test_case]

--- a/src/interrupts.rs
+++ b/src/interrupts.rs
@@ -1,4 +1,5 @@
 use crate::println;
+use crate::gdt;
 use lazy_static::lazy_static;
 use x86_64::structures::idt::{InterruptDescriptorTable, InterruptStackFrame};
 
@@ -6,7 +7,13 @@ lazy_static! {
     static ref IDT: InterruptDescriptorTable = {
         let mut idt = InterruptDescriptorTable::new();
         idt.breakpoint.set_handler_fn(breakpoint_handler);
-        idt.double_fault.set_handler_fn(double_fault_handler);
+
+        unsafe {
+            idt.double_fault
+                .set_handler_fn(double_fault_handler)
+                .set_stack_index(gdt::DOUBLE_FAULT_IST_INDEX);
+        }
+
         idt
     };
 }

--- a/src/interrupts.rs
+++ b/src/interrupts.rs
@@ -28,7 +28,7 @@ extern "x86-interrupt" fn breakpoint_handler(stack_frame: &mut InterruptStackFra
 
 extern "x86-interrupt" fn double_fault_handler(
     stack_frame: &mut InterruptStackFrame,
-    _error_code: u64
+    _error_code: u64,
 ) -> ! {
     panic!("[EXCEPTION]: DOUBLE FAULT\n{:#?}", stack_frame);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,10 @@ use core::panic::PanicInfo;
 pub mod interrupts;
 pub mod serial;
 pub mod vga_buffer;
+pub mod gdt;
 
 pub fn init() {
+    gdt::init();
     interrupts::init_idt();
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,10 +7,10 @@
 
 use core::panic::PanicInfo;
 
+pub mod gdt;
 pub mod interrupts;
 pub mod serial;
 pub mod vga_buffer;
-pub mod gdt;
 
 pub fn init() {
     gdt::init();

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,18 +23,6 @@ pub extern "C" fn _start() -> ! {
     // Causes a breakpoint exception
     x86_64::instructions::interrupts::int3();
 
-    // Causes a double fault exception by writing to an unmapped memory area
-    // unsafe {
-    //     *(0xdeadbeef as *mut u64) = 42;
-    // }
-
-    // Causes a kernel stack overflow with an endless recursive function
-    // fn stack_overflow() {
-    //     stack_overflow();
-    // }
-    //
-    // stack_overflow();
-
     #[cfg(test)]
     test_main();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,11 +29,11 @@ pub extern "C" fn _start() -> ! {
     // }
 
     // Causes a kernel stack overflow with an endless recursive function
-    fn stack_overflow() {
-        stack_overflow();
-    }
-
-    stack_overflow();
+    // fn stack_overflow() {
+    //     stack_overflow();
+    // }
+    //
+    // stack_overflow();
 
     #[cfg(test)]
     test_main();

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,11 +20,20 @@ pub extern "C" fn _start() -> ! {
         42, 3.1417
     );
 
+    // Causes a breakpoint exception
     x86_64::instructions::interrupts::int3();
 
-    unsafe {
-        *(0xdeadbeef as *mut u64) = 42;
+    // Causes a double fault exception by writing to an unmapped memory area
+    // unsafe {
+    //     *(0xdeadbeef as *mut u64) = 42;
+    // }
+
+    // Causes a kernel stack overflow with an endless recursive function
+    fn stack_overflow() {
+        stack_overflow();
     }
+
+    stack_overflow();
 
     #[cfg(test)]
     test_main();

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,6 @@ use fractal_os::{print, println};
 // Don't mangle the entry point function name
 #[no_mangle]
 pub extern "C" fn _start() -> ! {
-
     fractal_os::init();
 
     println!("Hello, world!");

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,9 @@ use fractal_os::{print, println};
 // Don't mangle the entry point function name
 #[no_mangle]
 pub extern "C" fn _start() -> ! {
+
+    fractal_os::init();
+
     println!("Hello, world!");
     println!("My name is {}", "Martin");
     print!(
@@ -17,9 +20,11 @@ pub extern "C" fn _start() -> ! {
         42, 3.1417
     );
 
-    fractal_os::init();
-
     x86_64::instructions::interrupts::int3();
+
+    unsafe {
+        *(0xdeadbeef as *mut u64) = 42;
+    }
 
     #[cfg(test)]
     test_main();

--- a/tests/stack_overflow.rs
+++ b/tests/stack_overflow.rs
@@ -2,11 +2,11 @@
 #![no_main]
 #![feature(abi_x86_interrupt)]
 
+use core::borrow::Borrow;
 use core::panic::PanicInfo;
-use fractal_os::{exit_qemu, QemuExitCode, serial_print, serial_println};
+use fractal_os::{exit_qemu, serial_print, serial_println, QemuExitCode};
 use lazy_static::lazy_static;
 use x86_64::structures::idt::{InterruptDescriptorTable, InterruptStackFrame};
-use core::borrow::Borrow;
 
 lazy_static! {
     static ref TEST_IDT: InterruptDescriptorTable = {

--- a/tests/stack_overflow.rs
+++ b/tests/stack_overflow.rs
@@ -1,0 +1,62 @@
+#![no_std]
+#![no_main]
+#![feature(abi_x86_interrupt)]
+
+use core::panic::PanicInfo;
+use fractal_os::{exit_qemu, QemuExitCode, serial_print, serial_println};
+use lazy_static::lazy_static;
+use x86_64::structures::idt::{InterruptDescriptorTable, InterruptStackFrame};
+use core::borrow::Borrow;
+
+lazy_static! {
+    static ref TEST_IDT: InterruptDescriptorTable = {
+        let mut idt = InterruptDescriptorTable::new();
+
+        unsafe {
+            idt.double_fault
+                .set_handler_fn(test_double_fault_handler)
+                .set_stack_index(fractal_os::gdt::DOUBLE_FAULT_IST_INDEX);
+        }
+
+        idt
+    };
+}
+
+extern "x86-interrupt" fn test_double_fault_handler(
+    _stack_frame: &mut InterruptStackFrame,
+    _error_code: u64,
+) -> ! {
+    serial_println!("[ok]");
+    exit_qemu(QemuExitCode::Success);
+    loop {}
+}
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    serial_print!("stack_overflow::stack_overflow...\t");
+
+    fractal_os::gdt::init();
+    init_test_idt();
+
+    stack_overflow();
+
+    panic!("Execution continued after stack overflow");
+}
+
+pub fn init_test_idt() {
+    TEST_IDT.load();
+}
+
+#[allow(unconditional_recursion)]
+fn stack_overflow() {
+    // Recursively call itself
+    stack_overflow();
+
+    // This prevents tail recursion optimisation (Tail Call Elimination - https://en.wikipedia.org/wiki/Tail_call)
+    volatile::Volatile::new(0).borrow();
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    fractal_os::test_panic_handler(info);
+}


### PR DESCRIPTION
# What is a double fault exception?

A double fault is a special exception that occurs when the CPU fails to invoke an exception handler.

# What has been done in this PR?

- Added a basic double fault handler that prints out a panic error message along with the stack frame.
- Created integration test to test the handling functionality.
- Enabled hardware supported stack switching on double fault exceptions so that they work on stack overflows.